### PR TITLE
add upstream and filters

### DIFF
--- a/roles/forward-proxy/srv-nrcpod01-tiny/files/conf/filter
+++ b/roles/forward-proxy/srv-nrcpod01-tiny/files/conf/filter
@@ -3,3 +3,7 @@
 # For example: .*gov.bc.ca
 # ...would match the gov.bc.ca domain, as well as any of its subdomains.
 .*ca-central-1.amazonaws.com
+.*google.com
+hashicorp.com
+.*github.com
+.githubusercontent.com

--- a/roles/forward-proxy/srv-nrcpod01-tiny/files/conf/tinyproxy.conf
+++ b/roles/forward-proxy/srv-nrcpod01-tiny/files/conf/tinyproxy.conf
@@ -183,6 +183,9 @@ LogLevel Info
 #
 #Upstream http some.remote.proxy:port
 
+# Set upstream for IMDSv2 support in fluent bit
+upstream http 0.0.0.4:0 "169.254.0.0/16"
+
 #
 # MaxClients: This is the absolute highest number of threads which will
 # be created. In other words, only MaxClients number of clients can be


### PR DESCRIPTION
Adding upstream to handle IMDSv2 support for fluent bit v1.8.8 and higher. Also added filters required for agent deployment.